### PR TITLE
Move all MeiliSearch references to the new brand

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Your contributions are always welcome!
     * Add the section description
     * Add the section title to the Table of Contents
 * Search previous Pull Requests or Issues before making a new one, as yours may be a duplicate
-* Don't mention `MeiliSearch` in the description as it's implied
+* Don't mention `Meilisearch` in the description as it's implied
 * Check your spelling and grammar
 * Remove any trailing whitespace
 * Description and content must be in English

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 MeiliSearch
+Copyright (c) 2021-2022 Meilisearch
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Awesome MeiliSearch
-A curated list of awesome MeiliSearch resources\
+# Awesome Meilisearch
+A curated list of awesome Meilisearch resources\
 Inspired by [Awesome Go](https://github.com/avelino/awesome-go) and [Awesome Python](https://github.com/vinta/awesome-python)
 
 ## Contributing
@@ -20,7 +20,7 @@ Please take a look at the [Contribution Guidelines](https://github.com/meilisear
 - [Demos](#demos)
 - [Talks](#talks)
 - [Blog Posts](#blog-posts)
-    - [MeiliSearch Blog Posts](#meilisearch-blog-posts)
+    - [Meilisearch Blog Posts](#meilisearch-blog-posts)
     - [Community Blog Posts](#community-blog-posts)
 - [Resources](#resources)
     - [Websites](#websites)
@@ -31,50 +31,50 @@ Please take a look at the [Contribution Guidelines](https://github.com/meilisear
 
 ## Guides, Tutorials and Courses
 
-*Learn MeiliSearch*
+*Learn Meilisearch*
 
 ### Official Guides
 
 #### Basics
 * [Quick Start](https://docs.meilisearch.com/learn/getting_started/quick_start.html)
 * [Installation](https://docs.meilisearch.com/learn/getting_started/installation.html)
-* [Update](https://docs.meilisearch.com/create/how_to/updating.html) - Update to the latest MeiliSearch version
-* [Run MeiliSearch in production](https://docs.meilisearch.com/create/how_to/running_production.html)
+* [Update](https://docs.meilisearch.com/create/how_to/updating.html) - Update to the latest Meilisearch version
+* [Run Meilisearch in production](https://docs.meilisearch.com/create/how_to/running_production.html)
 
 #### Deploy
-* [Deploy on AWS](https://docs.meilisearch.com/create/how_to/aws.html) - Deploy a MeiliSearch instance on Amazon Web Services (AWS)
-* [Deploy on GCP](https://docs.meilisearch.com/create/how_to/gcp.html) - Deploy a MeiliSearch instance on Google Cloud Platform (GCP) Compute Engine
-* [Deploy on DigitalOcean](https://docs.meilisearch.com/create/how_to/digitalocean_droplet.html) - Deploy a MeiliSearch instance on DigitalOcean
-* [Deploy on Qovery](https://docs.meilisearch.com/create/how_to/qovery.html) - Deploy a MeiliSearch instance on Qovery
+* [Deploy on AWS](https://docs.meilisearch.com/create/how_to/aws.html) - Deploy a Meilisearch instance on Amazon Web Services (AWS)
+* [Deploy on GCP](https://docs.meilisearch.com/create/how_to/gcp.html) - Deploy a Meilisearch instance on Google Cloud Platform (GCP) Compute Engine
+* [Deploy on DigitalOcean](https://docs.meilisearch.com/create/how_to/digitalocean_droplet.html) - Deploy a Meilisearch instance on DigitalOcean
+* [Deploy on Qovery](https://docs.meilisearch.com/create/how_to/qovery.html) - Deploy a Meilisearch instance on Qovery
 
 #### Miscellaneous
-* [Use Postman with MeiliSearch](https://docs.meilisearch.com/create/how_to/postman_collection.html) - Postman collection for MeiliSearch
+* [Use Postman with Meilisearch](https://docs.meilisearch.com/create/how_to/postman_collection.html) - Postman collection for Meilisearch
 * [Integrate a relevant search bar to your documentation](https://docs.meilisearch.com/create/how_to/search_bar_for_docs.html)
-* [Use HTTP/2 and SSL with MeiliSearch](https://docs.meilisearch.com/create/how_to/http2_ssl.html)
+* [Use HTTP/2 and SSL with Meilisearch](https://docs.meilisearch.com/create/how_to/http2_ssl.html)
 
 ### Community Guides
 * [Searching with Laravel Scout and Meilisearch](https://codecourse.com/courses/searching-with-laravel-scout-and-meilisearch) -  Build a search experience for any database data by combining Laravel Scout and Meilisearch
-* [Setting up Meilisearch on Production Ubuntu for Laravel project](https://postsrc.com/posts/setting-up-meilisearch-on-production-ubuntu-for-laravel-project) - How to set up MeiliSearch for a Laravel project
-* [Adding Search to Rails with MeiliSearch](https://blog.cloud66.com/adding-search-to-rails-with-meilisearch/) - How to integrate MeiliSearch in a Rails app
-* [How to Install a Specific Version of MeiliSearch](https://medium.com/@biarosenbaum/how-to-install-a-specific-version-of-meilisearch-2552bee8c351)
-* [How I implemented full-text search on Firebase with MeiliSearch for Secrets App](https://medium.com/@stevapps256/how-i-implemented-full-text-search-on-firebase-with-meilisearch-for-secrets-app-6b853484c999) - How to integrate MeiliSearch on Firebase
-* [Deploy MeiliSearch with Dokku for production](https://okhlopkov.com/deploy-meilisearch-with-dokku-for-production/) - How to deploy MeiliSearch with Dokku
-* [How to Deploy MeiliSearch on Laravel Forge](https://postsrc.com/posts/how-to-deploy-meilisearch-on-laravel-forge)
-* [Master Full Text Search with MeiliSearch on MinIO](https://blog.min.io/master-full-text-search-with-meilisearch-on-minio/) - How to use MinIO with MeiliSearch
+* [Setting up Meilisearch on Production Ubuntu for Laravel project](https://postsrc.com/posts/setting-up-meilisearch-on-production-ubuntu-for-laravel-project) - How to set up Meilisearch for a Laravel project
+* [Adding Search to Rails with Meilisearch](https://blog.cloud66.com/adding-search-to-rails-with-meilisearch/) - How to integrate Meilisearch in a Rails app
+* [How to Install a Specific Version of Meilisearch](https://medium.com/@biarosenbaum/how-to-install-a-specific-version-of-meilisearch-2552bee8c351)
+* [How I implemented full-text search on Firebase with Meilisearch for Secrets App](https://medium.com/@stevapps256/how-i-implemented-full-text-search-on-firebase-with-meilisearch-for-secrets-app-6b853484c999) - How to integrate Meilisearch on Firebase
+* [Deploy Meilisearch with Dokku for production](https://okhlopkov.com/deploy-meilisearch-with-dokku-for-production/) - How to deploy Meilisearch with Dokku
+* [How to Deploy Meilisearch on Laravel Forge](https://postsrc.com/posts/how-to-deploy-meilisearch-on-laravel-forge)
+* [Master Full Text Search with Meilisearch on MinIO](https://blog.min.io/master-full-text-search-with-meilisearch-on-minio/) - How to use MinIO with Meilisearch
 * [Serverless search with Meilisearch and Google Cloud Run](https://blog.simonireilly.com/posts/serverless-search)
-* [MeiliSearch: A definitive guide](https://blog.logrocket.com/meilisearch-a-definitive-guide/) - How to interact with an instance through the API client for JavaScript developers
-* [MeiliSearch under Windows](http://www.skrejci.com/2021/05/meilisearch-under-windows/) - Installing on Windows
-* [A Comprehensive Guide to MeiliSearch](https://www.atatus.com/blog/a-comprehensive-guide-to-meilisearch/)
+* [Meilisearch: A definitive guide](https://blog.logrocket.com/meilisearch-a-definitive-guide/) - How to interact with an instance through the API client for JavaScript developers
+* [Meilisearch under Windows](http://www.skrejci.com/2021/05/meilisearch-under-windows/) - Installing on Windows
+* [A Comprehensive Guide to Meilisearch](https://www.atatus.com/blog/a-comprehensive-guide-to-meilisearch/)
 * [How to add Search in Rails using Meilisearch](https://gorails.com/episodes/how-to-use-meilisearch-rails)
 
 **[⬆ back to top](#table-of-contents)**
 
 ## Integrations
 
-*MeiliSearch integrations created by MeiliSearch or the community*
+*Meilisearch integrations created by Meilisearch or the community*
 
 ### Official Integrations
-* [MeiliSearch official Integrations](https://github.com/meilisearch/integration-guides) - Central reference for MeiliSearch integrations
+* [Meilisearch official Integrations](https://github.com/meilisearch/integration-guides) - Central reference for Meilisearch integrations
 
 #### SDK
 
@@ -107,12 +107,12 @@ Please take a look at the [Contribution Guidelines](https://github.com/meilisear
 - [Strapi](https://github.com/meilisearch/strapi-plugin-meilisearch)
 
 ### Community Integrations
-* [MongoMeili](https://github.com/loophole-labs/mongomeili) - Sync MongooseJS Schemas with MeiliSearch
+* [MongoMeili](https://github.com/loophole-labs/mongomeili) - Sync MongooseJS Schemas with Meilisearch
 * [YunoHost](https://github.com/YunoHost-Apps/meilisearch_ynh) - Meilisearch on a YunoHost server
-* [D](https://github.com/aberba/meilisearch) - A MeiliSearch API for D
+* [D](https://github.com/aberba/meilisearch) - A Meilisearch API for D
 * [Craft CMS](https://github.com/unionco/craft-meilisearch) - Plugin for Craft CMS 3.x
 * [Airbyte](https://airbyte.io/connectors/meilisearch) - Connector for Airbyte
-* [Statamic MeiliSearch](https://statamic.com/addons/elvenstar/statamic-meilisearch) - Driver for Statamic 3
+* [Statamic Meilisearch](https://statamic.com/addons/elvenstar/statamic-meilisearch) - Driver for Statamic 3
 * [Medusa](https://github.com/medusajs/medusa/tree/master/packages/medusa-plugin-meilisearch) - Plugin for Medusa
 * [Meili Ktr](https://github.com/JonathanxD/meili-ktr) - A multiplatform Kotlin client
 * [Yii2](https://github.com/zhuzixian520/yii2-meilisearch) - Yii2 framework extension
@@ -123,10 +123,10 @@ Please take a look at the [Contribution Guidelines](https://github.com/meilisear
 
 ## Tools
 
-*Tools created by MeiliSearch or the community*
+*Tools created by Meilisearch or the community*
 
 ### Official Tools
-* [MeiliSearch Version Migration Script](https://github.com/meilisearch/meilisearch-migration) - A script to migrate to a newer wersion without losing data nor settings
+* [Meilisearch Version Migration Script](https://github.com/meilisearch/meilisearch-migration) - A script to migrate to a newer wersion without losing data nor settings
 
 #### DevOps Tools
 
@@ -137,52 +137,52 @@ Please take a look at the [Contribution Guidelines](https://github.com/meilisear
 * [Cloud Scripts](https://github.com/meilisearch/cloud-scripts) - A set of cloud-agnostic tools and scripts to improve deployment on the cloud
 
 #### Miscellaneous
-* [instant-meilisearch](https://github.com/meilisearch/instant-meilisearch) - A plugin to establish the communication between MeiliSearch and the open-source [InstantSearch](https://github.com/algolia/instantsearch.js) tools (powered by Algolia)
+* [instant-meilisearch](https://github.com/meilisearch/instant-meilisearch) - A plugin to establish the communication between Meilisearch and the open-source [InstantSearch](https://github.com/algolia/instantsearch.js) tools (powered by Algolia)
 * [docs-searchbar.js](https://github.com/meilisearch/docs-searchbar.js) - A search bar integration for all kinds of documentation
-* [docs-scraper](https://github.com/meilisearch/docs-scraper) -  A scraper tool to automatically read the content of your documentation and store it into MeiliSearch.
+* [docs-scraper](https://github.com/meilisearch/docs-scraper) -  A scraper tool to automatically read the content of your documentation and store it into Meilisearch.
 
 ### Community Tools
 * [AIO_MEILISEARCH](https://github.com/devtud/aio_meilisearch) - Async Wrapper over Meilisearch REST API
 * [mieli](https://github.com/irevoire/mieli) - A wrapper
-* [MeiliSearch CLI](https://github.com/sanders41/meilisearch-cli) - A CLI
+* [Meilisearch CLI](https://github.com/sanders41/meilisearch-cli) - A CLI
 * [UIRecord](https://github.com/SaraVieira/uirecord) -  A UI to manage instances
 
 **[⬆ back to top](#table-of-contents)**
 
 ## Demos
 
-*See MeiliSearch in action*
+*See Meilisearch in action*
 
-* [MeiliSearch Demos](https://github.com/meilisearch/demos)
-* [MeiliSearch x MoMA](https://github.com/meilisearch/demos/tree/main/src/MoMA) - Search through the Museum Of Modern Art Collection
-* [Search in Nobel Prizes with MeiliSearch](https://github.com/meilisearch/demos/tree/main/src/nobel-prizes) - Search through all Nobel Prize winners and their details
-* [MeiliSearch finds RubyGems](https://github.com/meilisearch/demos/tree/main/src/finding-rubygems) - Find Ruby gems
+* [Meilisearch Demos](https://github.com/meilisearch/demos)
+* [Meilisearch x MoMA](https://github.com/meilisearch/demos/tree/main/src/MoMA) - Search through the Museum Of Modern Art Collection
+* [Search in Nobel Prizes with Meilisearch](https://github.com/meilisearch/demos/tree/main/src/nobel-prizes) - Search through all Nobel Prize winners and their details
+* [Meilisearch finds RubyGems](https://github.com/meilisearch/demos/tree/main/src/finding-rubygems) - Find Ruby gems
 * [Finding Crates](https://github.com/meilisearch/demos/tree/main/src/finding-crates) - Find Rust crates
-* [MeiliSearch finds PyPI packages](https://github.com/meilisearch/demos/tree/main/src/finding-pypi) - Find Python packages
+* [Meilisearch finds PyPI packages](https://github.com/meilisearch/demos/tree/main/src/finding-pypi) - Find Python packages
 * [Search in world cities](https://github.com/meilisearch/demos/tree/main/src/geo-javascript) - Play with Geosearch features and find info about large cities
 
 **[⬆ back to top](#table-of-contents)**
 
 ## Talks
 
-*Talks about MeiliSearch*
+*Talks about Meilisearch*
 
 * [Rawkode Live: Introduction to Meilisearch](https://www.youtube.com/watch?v=SJl2UWfy1nk)
 * [Strapi conf 2021: Integrate open-source search into your Strapi project](https://www.youtube.com/watch?v=brG3738V2bU)
-* [Strapi webinar: Modern Search Solutions for the Jamstack with MeiliSearch](https://www.youtube.com/watch?v=mO_I02ZAfmM&t=4s) - 
+* [Strapi webinar: Modern Search Solutions for the Jamstack with Meilisearch](https://www.youtube.com/watch?v=mO_I02ZAfmM&t=4s) - 
 
 
 **[⬆ back to top](#table-of-contents)**
 
 ## Blog Posts
 
-*Read what the MeiliSearch's team has written or what others say about us*
+*Read what the Meilisearch's team has written or what others say about us*
 
-### MeiliSearch Blog Posts
+### Meilisearch Blog Posts
 * [Latest's release blog post](https://blog.meilisearch.com/whats-new-in-v0-23/) - version 0.23
 
 ### Community Blog Posts
-* [MeiliSearch: A Minimalist Full-Text Search Engine](https://tech.marksblogg.com/meilisearch-full-text-search.html)
+* [Meilisearch: A Minimalist Full-Text Search Engine](https://tech.marksblogg.com/meilisearch-full-text-search.html)
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -191,19 +191,19 @@ Please take a look at the [Contribution Guidelines](https://github.com/meilisear
 *Various resources*
 
 ### Repositories
-* [MeiliSearch](https://github.com/meilisearch/MeiliSearch)
-* [milli](https://github.com/meilisearch/milli/) - MeiliSearch's core engine
+* [Meilisearch](https://github.com/meilisearch/Meilisearch)
+* [milli](https://github.com/meilisearch/milli/) - Meilisearch's core engine
 * [Product repository](https://github.com/meilisearch/product)
 
 ### Websites
-* [Website](https://www.meilisearch.com/) - The official MeiliSearch website
-* [Blog](https://blog.meilisearch.com/) - The official MeiliSearch blog
-* [Documentation](https://docs.meilisearch.com/) - The official MeiliSearch documentation
-* [Roadmap](https://roadmap.meilisearch.com/) - The official MeiliSearch roadmap
+* [Website](https://www.meilisearch.com/) - The official Meilisearch website
+* [Blog](https://blog.meilisearch.com/) - The official Meilisearch blog
+* [Documentation](https://docs.meilisearch.com/) - The official Meilisearch documentation
+* [Roadmap](https://roadmap.meilisearch.com/) - The official Meilisearch roadmap
 
 ### Social Networks
-* [Twitter](https://twitter.com/meilisearch) - The official MeiliSearch Twitter account
-* [Linkedin](https://www.linkedin.com/company/meilisearch/) - The official MeiliSearch Linkedin account
+* [Twitter](https://twitter.com/meilisearch) - The official Meilisearch Twitter account
+* [Linkedin](https://www.linkedin.com/company/meilisearch/) - The official Meilisearch Linkedin account
 * [Slack](https://slack.meilisearch.com/) - The community Slack
 
 **[⬆ back to top](#table-of-contents)**
@@ -211,8 +211,8 @@ Please take a look at the [Contribution Guidelines](https://github.com/meilisear
 ## Other
 *Miscellaneous*
 * [Official FAQ](https://docs.meilisearch.com/faq.html)
-* [Companies & Organizations using MeiliSearch](https://github.com/meilisearch/devrel/blob/main/assets/companies.md) - A list of some of our users
-* [MeiliSearch in the media](https://github.com/meilisearch/devrel/blob/main/assets/media-appearance.md) - A list of appearances in the media
+* [Companies & Organizations using Meilisearch](https://github.com/meilisearch/devrel/blob/main/assets/companies.md) - A list of some of our users
+* [Meilisearch in the media](https://github.com/meilisearch/devrel/blob/main/assets/media-appearance.md) - A list of appearances in the media
 
 
 **[⬆ back to top](#table-of-contents)**


### PR DESCRIPTION
Just replace all `MeiliSearch` by `Meilisearch` 😄 