### PR TITLE
Update LICENSE to the new naming guidelines

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2022 Meilisearch
+Copyright (c) 2021-2022 Meili SAS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I created an automated PR for all the integration repositories, but this one I couldn't because it does not have a particular label `skip-changelog`. 