### PR TITLE
Add Spring Data Meilisearch to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Please take a look at the [Contribution Guidelines](https://github.com/meilisear
 * [meilisync](https://github.com/meilisync/meilisync) - Real time data sync from MySQL, PostgreSQL, or MongoDB
 * [CloudQuery](https://www.cloudquery.io/docs/plugins/destinations/meilisearch/overview) - Syncs data from any CloudQuery source plugins to a Meilisearch instance
 * [Meilisearch.st](https://github.com/mumez/Meilisearch.st) - A client for Smalltalk
+* [Spring Data Meilisearch](https://github.com/junghoon-vans/spring-data-meilisearch) - Spring Data Implementation for Meilisearch
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
# Pull Request

## Related issue
None

## What does this PR do?

[Spring Data Meilisearch](https://github.com/junghoon-vans/spring-data-meilisearch) provides the integration of meilisearch with the Spring framework.
An abstract layer called `Repository` in Spring Data allows for easy data processing.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
