### PR TITLE
Add Wallaby link

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Please take a look at the [Contribution Guidelines](https://github.com/meilisear
 * [Spring Data Meilisearch](https://github.com/junghoon-vans/spring-data-meilisearch) - Spring Data Implementation for Meilisearch
 * [django-meili](https://github.com/ikollipara/django-meili) - Django integration with Meilisearch
 * [django-meilisearch-indexer](https://github.com/Jordan-Kowal/django-meilisearch-indexer) - Meilisearch indexer for django models and related utilities
+* [Wallaby](https://wallabycdc.net/) - Postgres CDC Engine for .NET w/ realtime sync into Meilisearch
+
 * ARCHIVED: ~[MongoMeili](https://github.com/loophole-labs/mongomeili) - Sync MongooseJS Schemas with Meilisearch~
 
 **[⬆ back to top](#table-of-contents)**


### PR DESCRIPTION
Adds a link to the [Wallaby](https://wallabycdc.net/) project as it features a first-class Meilisearch integration


